### PR TITLE
Fix navigation bar not to cover page contents when it goes multi-line

### DIFF
--- a/_include/css/bootstrap.css
+++ b/_include/css/bootstrap.css
@@ -3769,7 +3769,6 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .navbar {
   position: relative;
   min-height: 50px;
-  margin-bottom: 20px;
   border: 1px solid transparent;
 }
 @media (min-width: 768px) {

--- a/_include/css/mamedev.css
+++ b/_include/css/mamedev.css
@@ -3,10 +3,6 @@ body {
     height: 100%;
 }
 
-body {
-    padding-top: 50px; /* Required padding for .navbar-fixed-top. Remove if using .navbar-static-top. Change if height of navigation changes. */
-}
-
 .img-center {
 	margin: 0 auto;
 }

--- a/_include/html/header.html
+++ b/_include/html/header.html
@@ -32,9 +32,7 @@
 </head>
 
 <body>
-	<a href="http://github.com/mamedev/mame"><img style="position: absolute; top: 50px; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a>
-
-<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+<nav class="navbar navbar-default navbar-static-top" role="navigation">
 	<div class="container">
 		<!-- Brand and toggle get grouped for better mobile display -->
 		<div class="navbar-header">
@@ -112,3 +110,4 @@
 	</div><!-- /.container-fluid -->
 </nav>
 
+<a href="http://github.com/mamedev/mame"><img style="position: absolute; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a>


### PR DESCRIPTION
- Make navbar static instead of fixed.
- Drop navbar's margin-bottom.
Can't say what it was there for, but it shifted everything down with a static navbar.
- Drop body's padding-top.
The css file explicitly mentions this.
- Put the forkme image after navbar in the code, so it's also not covered by it.
- Remove the top value of the image.
Hard-codedd to be below the single-line navbar, breaks in all other cases, not needed anymore.

Before/after:
https://i.imgur.com/pbJnmzX.png -> https://i.imgur.com/PQAZZ6W.png
https://i.imgur.com/dYv1aLb.png -> https://i.imgur.com/sMWwhM8.png
https://i.imgur.com/JVHjvum.png -> https://i.imgur.com/G4v9DFa.png
https://i.imgur.com/vFlYnlV.png -> https://i.imgur.com/57DuHt2.png

The current view is how it looks in all browsers, but I only tested desktop. Mobile should be fine, since collapsed navbar looks the same either way. Drop-down lists are fine too.