### PR TITLE
Offset page contents vertically to account for changing navbar height

### DIFF
--- a/_include/css/mamedev.css
+++ b/_include/css/mamedev.css
@@ -79,3 +79,28 @@ footer {
         height: 70%;
     }
 }
+
+@media (max-width: 286px) {
+    body {
+        padding-top: 100px;
+    }
+}
+
+@media (min-width: 768px) {
+    body {
+        padding-top: 150px;
+    }
+}
+
+@media (min-width: 992px) {
+    body {
+        padding-top: 100px;
+    }
+}
+
+@media (min-width: 1200px) {
+    body {
+        padding-top: 50px;
+    }
+  }
+}

--- a/_include/html/header.html
+++ b/_include/html/header.html
@@ -32,7 +32,7 @@
 </head>
 
 <body>
-	<a href="http://github.com/mamedev/mame"><img style="position: absolute; top: 50px; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a>
+	<a href="http://github.com/mamedev/mame"><img style="position: absolute; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a>
 
 <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
 	<div class="container">


### PR DESCRIPTION
The goal is to prevent page contents from getting covered, like in #15, just to do it the right way

"Container" uses the values I used here, to determine its width. I added max-width, based on the width that makes navbar become 2-lined at super low res.

Forkme image gets shifted the same way, no need to hard-code its height to 50.

Wikipages use custom set of styles (with entirely different padding values), not mamedev.css, so it shouldn't be affected and needs to be fixed separately.