### PR TITLE
Correct Exidy and Kauffman typos.

### DIFF
--- a/roms/carpolo/index.php
+++ b/roms/carpolo/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Car Polo (Exidy, 1977)';
 
 	<center><h1 class="page-header">Car Polo (Exidy, 1977)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Car Polo</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Car Polo</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/circus/index.php
+++ b/roms/circus/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Circus (Exidy, 1977)';
 
 	<center><h1 class="page-header">Circus (Exidy, 1977)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Circus</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Circus</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/crash/index.php
+++ b/roms/crash/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Crash (Exidy, 1979)';
 
 	<center><h1 class="page-header">Crash (Exidy, 1979)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Crash</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Crash</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/fax/index.php
+++ b/roms/fax/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | FAX (Exidy, 1983)';
 
 	<center><h1 class="page-header">FAX (Exidy, 1983)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>FAX</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>FAX</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/fireone/index.php
+++ b/roms/fireone/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Fire One (Exidy, 1979)';
 
 	<center><h1 class="page-header">Fire One (Exidy, 1979)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Fire One</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Fire One</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/hardhat/index.php
+++ b/roms/hardhat/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Hard Hat (Exidy, 1982)';
 
 	<center><h1 class="page-header">Hard Hat (Exidy, 1982)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Hard Hat</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Hard Hat</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/ripcord/index.php
+++ b/roms/ripcord/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Rip Cord (Exidy, 1979)';
 
 	<center><h1 class="page-header">Rip Cord (Exidy, 1979)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Rip Cord</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Rip Cord</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/robotbwl/index.php
+++ b/roms/robotbwl/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Robot Bowl (Exidy, 1977)';
 
 	<center><h1 class="page-header">Robot Bowl (Exidy, 1977)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Robot Bowl</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Robot Bowl</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/sidetrac/index.php
+++ b/roms/sidetrac/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Side Trak (Exidy, 1979)';
 
 	<center><h1 class="page-header">Side Trak (Exidy, 1979)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Side Trak</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Side Trax</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/spectar/index.php
+++ b/roms/spectar/index.php
@@ -7,10 +7,10 @@ $title = 'MAME | Spectar (Exidy, 1980)';
 <div class="container">
 
 	<center><h1 class="page-header">Spectar (Exidy, 1980)</h1></center>
-
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Spectar</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Spectar</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/starfire/index.php
+++ b/roms/starfire/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Star Fire (Exidy, 1979)';
 
 	<center><h1 class="page-header">Star Fire (Exidy, 1979)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Star Fire</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Star Fire</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/targ/index.php
+++ b/roms/targ/index.php
@@ -9,8 +9,9 @@ $title = 'MAME | Targ (Exidy, 1980)';
 	<center><h1 class="page-header">Targ (Exidy, 1980)</h1></center>
 
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Targ</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Targ</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/teetert/index.php
+++ b/roms/teetert/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Teeter Torture (Exidy, 1982)';
 
 	<center><h1 class="page-header">Teeter Torture (Exidy, 1982)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Teeter Torture</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Teeter Torture</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/topgunnr/index.php
+++ b/roms/topgunnr/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Top Gunner / Vertigo (Exidy, 1986)';
 
 	<center><h1 class="page-header">Top Gunner / Vertigo (Exidy, 1986)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Top Gunner</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Top Gunner</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>

--- a/roms/victory/index.php
+++ b/roms/victory/index.php
@@ -8,8 +8,9 @@ $title = 'MAME | Victory (Exidy, 1982)';
 
 	<center><h1 class="page-header">Victory (Exidy, 1982)</h1></center>
 						<p>
-						Thanks to the kind generosity of H.R. Kaufmann, president of Xidy, the original ROM images for
-						<b>Victory</b> have been made available for free, non-commercial use.
+						Thanks to the kind generosity of H.R. Kauffman, founder of Exidy and later president of the
+						holding company Xidy, Inc., the original ROM images for <b>Victory</b> have been made
+                                                available for free, non-commercial use.
 						</p>
 
 						<p>


### PR DESCRIPTION
Obituary with correct spelling: https://www.gamasutra.com/view/news/247873/Obituary_Exidy_founder_Pete_Kauffman.php